### PR TITLE
Get CommandBox latest stable version on CI runtime

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -25,7 +25,7 @@ jobs:
       run: |
         date_version=$(date +%Y.%m)
         echo $date_version > ./version.txt
-        docker build . --file Dockerfile --tag minibox
+        docker build . --file Dockerfile --tag minibox -e BOX_VERSION=${{ env.BOX_VERSION }}
         docker-compose build
         docker-compose up
         echo "${{ secrets.DOCKER_PASS }}" | docker login --username ${{ secrets.DOCKER_USER }} --password-stdin

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -14,13 +14,18 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - id: get_box_version
-      run: |
-        curl --location -O https://s3.amazonaws.com/downloads.ortussolutions.com/ortussolutions/commandbox/box-repo.json
-        echo "json=`cat box-repo.json`" >> $GITHUB_OUTPUT
-    - run: |
-        echo "BOX_VERSION=${{fromJson(steps.get_box_version.outputs.json).versioning.stableVersion}}" >> $GITHUB_ENV
+    - run: curl --location -O https://s3.amazonaws.com/downloads.ortussolutions.com/ortussolutions/commandbox/box-repo.json
+    
+    - name: Extract version from box-repo.json
+      uses: sergeysova/jq-action@v2
+      id: version
+      with:
+        cmd: 'jq .versioning.stableVersion box-repo.json'
+    
+    - run: echo "BOX_VERSION=${{ steps.version.outputs.value }}" >> $GITHUB_ENV
+    
     - run: echo ${{ env.BOX_VERSION }}
+    
     - name: Build and Publish the Docker image
       run: |
         date_version=$(date +%Y.%m)

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -14,6 +14,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - id: get_box_version
+      run: |
+        curl --location -o https://s3.amazonaws.com/downloads.ortussolutions.com/ortussolutions/commandbox/box-repo.json
+        echo "json=`cat box-repo.json`" >> $GITHUB_OUTPUT
+    - run: |
+        echo "BOX_VERSION=${{fromJson(steps.get_box_version.outputs.json).versioning.stableVersion}}" >> $GITHUB_ENV
+    - run: echo ${{ env.BOX_VERSION }}
     - name: Build and Publish the Docker image
       run: |
         date_version=$(date +%Y.%m)

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -30,7 +30,7 @@ jobs:
       run: |
         date_version=$(date +%Y.%m)
         echo $date_version > ./version.txt
-        docker build . --file Dockerfile --tag minibox -e BOX_VERSION=${{ env.BOX_VERSION }}
+        docker build . --file Dockerfile --tag minibox --build-arg BOX_VERSION=${{ env.BOX_VERSION }}
         docker-compose build
         docker-compose up
         echo "${{ secrets.DOCKER_PASS }}" | docker login --username ${{ secrets.DOCKER_USER }} --password-stdin

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -45,5 +45,3 @@ jobs:
           date_version=$(date +%Y.%m)
           docker tag minibox $IMAGE_ID:$date_version
           docker push $IMAGE_ID:$date_version
-          
-        

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v2
     - id: get_box_version
       run: |
-        curl --location -o https://s3.amazonaws.com/downloads.ortussolutions.com/ortussolutions/commandbox/box-repo.json
+        curl --location -O https://s3.amazonaws.com/downloads.ortussolutions.com/ortussolutions/commandbox/box-repo.json
         echo "json=`cat box-repo.json`" >> $GITHUB_OUTPUT
     - run: |
         echo "BOX_VERSION=${{fromJson(steps.get_box_version.outputs.json).versioning.stableVersion}}" >> $GITHUB_ENV

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM azul/zulu-openjdk-alpine:8-jre AS build
 
 RUN apk add zip unzip curl
 
-ARG BOX_VERSION = 5.8.0
+ARG BOX_VERSION=5.8.0
 
 RUN mkdir /opt/box
 RUN curl --location -o /opt/box/box https://s3.amazonaws.com/downloads.ortussolutions.com/ortussolutions/commandbox/$BOX_VERSION/box-light

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM azul/zulu-openjdk-alpine:8-jre AS build
 RUN apk add zip unzip curl
 
 RUN mkdir /opt/box
-RUN curl --location -o /opt/box/box https://s3.amazonaws.com/downloads.ortussolutions.com/ortussolutions/commandbox/5.8.0/box-light
+RUN curl --location -o /opt/box/box https://s3.amazonaws.com/downloads.ortussolutions.com/ortussolutions/commandbox/$BOX_VERSION/box-light
 
 RUN chmod -R a+rx /opt/box/box 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN rm -f /root/.CommandBox/engine/cfml/cli/cfml-web/context/lucee-applet.jar
 RUN rm -f /root/.CommandBox/engine/cfml/cli/cfml-web/context/lucee-admin.lar
 RUN rm -f /root/.CommandBox/engine/cfml/cli/cfml-web/context/lucee-doc.lar
 
-RUN curl --location -o /opt/box/box-thin https://s3.amazonaws.com/downloads.ortussolutions.com/ortussolutions/commandbox/5.8.0/box-thin
+RUN curl --location -o /opt/box/box-thin https://s3.amazonaws.com/downloads.ortussolutions.com/ortussolutions/commandbox/$BOX_VERSION/box-thin
 
 RUN mv /opt/box/box-thin /opt/box/box
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM azul/zulu-openjdk-alpine:8-jre AS build
 
 RUN apk add zip unzip curl
 
+ARG BOX_VERSION = 5.8.0
+
 RUN mkdir /opt/box
 RUN curl --location -o /opt/box/box https://s3.amazonaws.com/downloads.ortussolutions.com/ortussolutions/commandbox/$BOX_VERSION/box-light
 


### PR DESCRIPTION
This PR uses CommandBox's [published versioning json file](https://s3.amazonaws.com/downloads.ortussolutions.com/ortussolutions/commandbox/box-repo.json) to retrieve the latest stable version number. Once that is done, the CI passes the obtained version through the `docker build` command and builds a new minibox image.

Once this PR is merged, bumping the commandbox version in Minibox is as easy as firing off a new build.

I recommend squashing when merging, it's not a big change. (Mostly in the GHA workflow)